### PR TITLE
[BL-008] Backlog steward docs and rules

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,7 @@
+# Backlog
+
+This file moved to `docs/backlog/BACKLOG.md`.
+
+- Human backlog: [docs/backlog/BACKLOG.md](docs/backlog/BACKLOG.md)
+- Machine backlog: [docs/backlog/backlog.yaml](docs/backlog/backlog.yaml)
+- Usage guide: [docs/backlog/USAGE.md](docs/backlog/USAGE.md)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,0 @@
-# Backlog
-
-This file moved to `docs/backlog/BACKLOG.md`.
-
-- Human backlog: [docs/backlog/BACKLOG.md](docs/backlog/BACKLOG.md)
-- Machine backlog: [docs/backlog/backlog.yaml](docs/backlog/backlog.yaml)
-- Usage guide: [docs/backlog/USAGE.md](docs/backlog/USAGE.md)

--- a/docs/backlog/BACKLOG.md
+++ b/docs/backlog/BACKLOG.md
@@ -33,6 +33,7 @@
   - Acceptance Criteria:
     - Backlog USAGE.md documents capture/persist, branch naming, commit format, PR rules, lifecycle commands, minimal diffs, hygiene, guardrails.
     - Branch naming enforced in docs and used in new work: `<type>/<BL-###>-<kebab-title>`.
+    - All new branches are created from `main` (default branch).
     - Commits include `[BL-###]` suffix and conventional type(scope).
     - PR template/title guidance added; PRs include acceptance and checklist.
   - Status: in-progress

--- a/docs/backlog/BACKLOG.md
+++ b/docs/backlog/BACKLOG.md
@@ -1,0 +1,80 @@
+# Backlog
+
+## NOW (P0)
+
+- BL-001: Minimal CI stability and linting (ops)
+  - Type: techdebt
+  - Priority: P0
+  - Why: Keep PR CI green with flat ESLint config and TS checks.
+  - Acceptance Criteria:
+    - CI runs lint, typecheck, build on PRs to dev/main.
+    - eslint config uses flat ESM; no config errors.
+    - Lint has 0 errors (warnings allowed).
+    - Repo builds without interactive input.
+  - Status: in-progress
+  - Links: branch chore/simple-ci-and-docs
+
+## NEXT (P1)
+
+- BL-002: Server test suite expansion (server)
+  - Type: techdebt
+  - Priority: P1
+  - Why: Cover routes/middleware/services, esp. SC2Pulse caching and error mapping.
+  - Acceptance Criteria:
+    - Vitest server suite covers pulseRoutes, pulseApi, error handlers.
+    - v8 coverage ≥ 60% server-side.
+    - Tests run non-interactively via npm scripts.
+  - Status: planned
+  - Links: branch test/server-suite
+
+- BL-003: Client coverage scoping and scaffolding (client)
+  - Type: techdebt
+  - Priority: P1
+  - Why: Avoid noise from non-client files and build a base for RTL/MSW tests.
+  - Acceptance Criteria:
+    - vitest.client.config.ts coverage.include limited to src/client/**
+    - Pass with no tests enabled; sample test scaffold added.
+  - Status: planned
+  - Links: branch test/client-coverage-scope
+
+## LATER (P2)
+
+- BL-004: Repo docs and contribution model (docs)
+  - Type: docs
+  - Priority: P2
+  - Why: Ensure consistent PR flow, branching, and CI expectations.
+  - Acceptance Criteria:
+    - CONTRIBUTING.md documents delivery model and CI scope.
+    - CODEOWNERS added for key areas.
+    - README references contributing.
+  - Status: done
+  - Links: branches docs/repo-docs, chore/simple-ci-and-docs
+
+- BL-005: Simplify workflows to single CI (ops)
+  - Type: techdebt
+  - Priority: P2
+  - Why: Reduce maintenance surface; rely on Vercel for deploys.
+  - Acceptance Criteria:
+    - Only .github/workflows/ci.yml exists.
+    - Old Deploy.yml removed.
+  - Status: done
+  - Links: branch chore/simple-ci-and-docs
+
+## NICE TO HAVE (P3)
+
+- BL-006: Security and governance baseline (ops)
+  - Type: techdebt
+  - Priority: P3
+  - Why: Enforce branch protections, required checks, secret scanning, and Dependabot.
+  - Acceptance Criteria:
+    - Branch protections on main/dev (required CI, review, linear history).
+    - Dependabot alerts enabled and visible.
+    - Secret scanning + push protection on.
+    - Optional: CodeQL workflow.
+  - Status: planned
+  - Links: TODO
+
+## DONE
+
+- BL-004 moved to DONE (see above)
+- BL-005 moved to DONE (see above)

--- a/docs/backlog/BACKLOG.md
+++ b/docs/backlog/BACKLOG.md
@@ -26,6 +26,18 @@
   - Status: in-progress
   - Links: branch chore/simple-ci-and-docs
 
+- BL-008: Backlog steward enforcement (ops)
+  - Type: docs
+  - Priority: P0
+  - Why: Enforce branch/commit/PR conventions tied to backlog IDs for traceability and predictable delivery.
+  - Acceptance Criteria:
+    - Backlog USAGE.md documents capture/persist, branch naming, commit format, PR rules, lifecycle commands, minimal diffs, hygiene, guardrails.
+    - Branch naming enforced in docs and used in new work: `<type>/<BL-###>-<kebab-title>`.
+    - Commits include `[BL-###]` suffix and conventional type(scope).
+    - PR template/title guidance added; PRs include acceptance and checklist.
+  - Status: in-progress
+  - Links: branch docs/BL-008-backlog-steward-enforcement
+
 ## NEXT (P1)
 
 - BL-002: Server test suite expansion (server)

--- a/docs/backlog/BACKLOG.md
+++ b/docs/backlog/BACKLOG.md
@@ -49,7 +49,8 @@
     - Vitest server suite covers pulseRoutes, pulseApi, error handlers.
     - v8 coverage ≥ 60% server-side.
     - Tests run non-interactively via npm scripts.
-  - Status: planned
+  - Status: in-progress
+  - Notes: Initial server tests and fixtures added (routes, middleware, services). Vitest server config in place; SC2Pulse caching and error mapping covered. Tests run non-interactively.
   - Links: branch test/server-suite
 
 - BL-003: Client coverage scoping and scaffolding (client)
@@ -59,7 +60,8 @@
   - Acceptance Criteria:
     - vitest.client.config.ts coverage.include limited to src/client/**
     - Pass with no tests enabled; sample test scaffold added.
-  - Status: planned
+  - Status: in-progress
+  - Notes: Coverage include restricted to `src/client/**` and passWithNoTests enabled; preparing MSW/RTL test scaffolding.
   - Links: branch test/client-coverage-scope
 
 ## LATER (P2)

--- a/docs/backlog/BACKLOG.md
+++ b/docs/backlog/BACKLOG.md
@@ -14,6 +14,18 @@
   - Status: in-progress
   - Links: branch chore/simple-ci-and-docs
 
+- BL-007: Fix dual deploy env mapping (ops)
+  - Type: techdebt
+  - Priority: P0
+  - Why: Vercel now has dev/prod but both talk to the same Render instance; we need correct env separation to avoid cross-environment traffic.
+  - Acceptance Criteria:
+    - Vercel dev deploy points to Render dev (or isolated dev URL/env).
+    - Vercel prod deploy points to Render prod instance.
+    - Environment variables clearly scoped for dev vs prod in Vercel and Render.
+    - Documented mapping in README/CONTRIBUTING.
+  - Status: in-progress
+  - Links: branch chore/simple-ci-and-docs
+
 ## NEXT (P1)
 
 - BL-002: Server test suite expansion (server)

--- a/docs/backlog/USAGE.md
+++ b/docs/backlog/USAGE.md
@@ -77,6 +77,10 @@ If any field is missing, the steward will infer where possible; otherwise it wil
 
 ## Branch/Commit/PR Enforcement
 - Branch naming: `<type>/<BL-###>-<kebab-title>` where type ∈ {feature, fix, chore, docs, refactor, spike}.
+- Always create branches from `main` (default branch):
+  - `git fetch origin`
+  - `git checkout main && git pull --ff-only`
+  - `git checkout -b <type>/<BL-###>-<kebab-title>`
 - Commits: conventional commit + ticket suffix, e.g., `feat(client): concise message [BL-021]`.
 - PRs: Title `[BL-###] Clear title`; body links branch, lists acceptance criteria, test notes, and a release checklist.
 - Always link branch/PR/issue in both BACKLOG.md and backlog.yaml under the item’s Links.

--- a/docs/backlog/USAGE.md
+++ b/docs/backlog/USAGE.md
@@ -26,6 +26,20 @@ Write a line beginning with one of the following keywords; the steward will pars
 
 If any field is missing, the steward will infer where possible; otherwise it will add a TODO note in the item.
 
+### Parsing rules
+- Split fields by `|` when present; trim whitespace.
+- `why` is captured after the literal token `why ` until next `|` or end.
+- `ac:` starts acceptance criteria; split bullets by `;` or line breaks.
+- If `priority` missing, default to P2 unless the text implies urgency.
+- If `type` missing, infer from keywords: fix/bug → bug, feat/feature → feature, idea/todo → techdebt by default.
+- If `area` missing, infer from referenced files/branches; else set TODO.
+
+### Formatting expectations
+- BACKLOG.md: Keep section headers unchanged. Insert or move only the affected item.
+- backlog.yaml: Mirror all fields (id, title, type, area, priority, why, acceptance[], status, links).
+- IDs: Allocate next BL-### sequentially; do not reuse IDs.
+- Links: Use keys `branch`, `pr`, `issue` when available.
+
 ## Lifecycle Commands
 - promote BL-### to P0|P1|P2|P3
 - demote BL-### to P1|P2|P3
@@ -34,6 +48,7 @@ If any field is missing, the steward will infer where possible; otherwise it wil
 - link BL-### branch <name> / pr <#> / issue <#>
 - start BL-### (marks Status: in-progress)
 - done BL-### (moves item to DONE)
+  - Also set `status: done` in YAML; keep acceptance intact.
 
 ## Acceptance Criteria
 - Keep AC concrete and testable. Prefer bullets that can be verified in CI/tests.
@@ -57,3 +72,5 @@ If any field is missing, the steward will infer where possible; otherwise it wil
 - Persist updates to BOTH files with minimal diffs and keep sections in sync.
 - Consolidate near-duplicates; reference links (branch/pr/issue) when obvious.
 - Produce a short "Backlog delta" at the end of each session summarizing created/updated/promoted/done items.
+  - Format: Created [ids]; Updated [ids]; Promoted [ids]; Done [ids].
+  - If uncertain on any field: write "I don't know" and add a TODO note.

--- a/docs/backlog/USAGE.md
+++ b/docs/backlog/USAGE.md
@@ -72,5 +72,15 @@ If any field is missing, the steward will infer where possible; otherwise it wil
 - Persist updates to BOTH files with minimal diffs and keep sections in sync.
 - Consolidate near-duplicates; reference links (branch/pr/issue) when obvious.
 - Produce a short "Backlog delta" at the end of each session summarizing created/updated/promoted/done items.
-  - Format: Created [ids]; Updated [ids]; Promoted [ids]; Done [ids].
+  - Format: Δ Backlog: +N created (IDs) · M updated (IDs) · K done (IDs)
   - If uncertain on any field: write "I don't know" and add a TODO note.
+
+## Branch/Commit/PR Enforcement
+- Branch naming: `<type>/<BL-###>-<kebab-title>` where type ∈ {feature, fix, chore, docs, refactor, spike}.
+- Commits: conventional commit + ticket suffix, e.g., `feat(client): concise message [BL-021]`.
+- PRs: Title `[BL-###] Clear title`; body links branch, lists acceptance criteria, test notes, and a release checklist.
+- Always link branch/PR/issue in both BACKLOG.md and backlog.yaml under the item’s Links.
+
+## Guardrails (project practices)
+- Delivery flow: feature from main → Draft PR to dev → rebase on main for release → PR to main → merge → sync main→dev (rebase + --force-with-lease).
+- Quality: readability over cleverness; comment complex logic; error contract `{ error, code, context }`; structured logging; `process.env` for config; Vitest tests (server: axios + vi.hoisted; client: MSW + RTL).

--- a/docs/backlog/USAGE.md
+++ b/docs/backlog/USAGE.md
@@ -1,0 +1,59 @@
+# Backlog Steward Usage Guide
+
+This repo maintains a human-readable backlog (`docs/backlog/BACKLOG.md`) and a machine-readable mirror (`docs/backlog/backlog.yaml`). Use this guide for adding, updating, and evolving backlog items via chat.
+
+## Conventions
+- IDs: Use incremental `BL-###` identifiers (e.g., BL-007).
+- Types: `feature | bug | techdebt | docs`.
+- Areas: `client | server | ops`.
+- Priorities: `P0 (NOW) | P1 (NEXT) | P2 (LATER) | P3 (NICE TO HAVE)`.
+- Sections in BACKLOG.md:
+  - NOW (P0)
+  - NEXT (P1)
+  - LATER (P2)
+  - NICE TO HAVE (P3)
+  - DONE
+
+## Quick Commands (chat syntax)
+Write a line beginning with one of the following keywords; the steward will parse and persist updates in both files.
+
+- add: <title> | <type> | <area> | <priority> | why <reason> | ac: <bullet1>; <bullet2>; ...
+- idea: <title> | <area> | why <reason>
+- todo: <title> | <area> | ac: <bullets>
+- fix: <title> | area server | why <reason> | ac: <bullets>
+- feat: <title> | area client | ac: <bullets>
+- note: BL-### "<note text>"
+
+If any field is missing, the steward will infer where possible; otherwise it will add a TODO note in the item.
+
+## Lifecycle Commands
+- promote BL-### to P0|P1|P2|P3
+- demote BL-### to P1|P2|P3
+- retitle BL-### "New Title"
+- note BL-### "Additional context or decision"
+- link BL-### branch <name> / pr <#> / issue <#>
+- start BL-### (marks Status: in-progress)
+- done BL-### (moves item to DONE)
+
+## Acceptance Criteria
+- Keep AC concrete and testable. Prefer bullets that can be verified in CI/tests.
+- Example:
+  - CI runs eslint, typecheck, tests, build on PRs to dev/main
+  - ESLint flat config is ESM and loads without errors
+
+## Examples
+- add: Improve replay filter UX | feature | client | P2 | why streamline user workflow | ac: keyboard nav; keep filters in URL; RTL tests
+- fix: Pulse API retry jitter | bug | server | P1 | why reduce thundering-herd | ac: exponential backoff; de-dupe in-flight; tests
+- note: BL-002 "Mock SC2Pulse responses exist under mockData/"
+- promote BL-003 to P1
+- link BL-001 pr 42
+
+## File Locations
+- Human: `docs/backlog/BACKLOG.md`
+- Machine: `docs/backlog/backlog.yaml`
+
+## Steward Behavior
+- Capture & classify inputs from the chat based on the above grammar.
+- Persist updates to BOTH files with minimal diffs and keep sections in sync.
+- Consolidate near-duplicates; reference links (branch/pr/issue) when obvious.
+- Produce a short "Backlog delta" at the end of each session summarizing created/updated/promoted/done items.

--- a/docs/backlog/backlog.yaml
+++ b/docs/backlog/backlog.yaml
@@ -1,0 +1,85 @@
+items:
+  - id: BL-001
+    title: Minimal CI stability and linting
+    type: techdebt
+    area: ops
+    priority: P0
+    why: Keep PR CI green with flat ESLint config and TS checks.
+    acceptance:
+      - CI runs lint, typecheck, build on PRs to dev/main
+      - eslint config uses flat ESM; no config errors
+      - Lint has 0 errors (warnings allowed)
+      - Repo builds without interactive input
+    status: in-progress
+    links:
+      branch: chore/simple-ci-and-docs
+
+  - id: BL-002
+    title: Server test suite expansion
+    type: techdebt
+    area: server
+    priority: P1
+    why: Cover routes/middleware/services, esp. SC2Pulse caching and error mapping.
+    acceptance:
+      - Vitest server suite covers pulseRoutes, pulseApi, error handlers
+      - v8 coverage  60% server-side
+      - Tests run non-interactively via npm scripts
+    status: planned
+    links:
+      branch: test/server-suite
+
+  - id: BL-003
+    title: Client coverage scoping and scaffolding
+    type: techdebt
+    area: client
+    priority: P1
+    why: Avoid noise from non-client files and build a base for RTL/MSW tests.
+    acceptance:
+      - vitest.client.config.ts coverage.include limited to src/client/**
+      - Pass with no tests enabled; sample test scaffold added
+    status: planned
+    links:
+      branch: test/client-coverage-scope
+
+  - id: BL-004
+    title: Repo docs and contribution model
+    type: docs
+    area: ops
+    priority: P2
+    why: Ensure consistent PR flow, branching, and CI expectations.
+    acceptance:
+      - CONTRIBUTING.md documents delivery model and CI scope
+      - CODEOWNERS added for key areas
+      - README references contributing
+    status: done
+    links:
+      branches:
+        - docs/repo-docs
+        - chore/simple-ci-and-docs
+
+  - id: BL-005
+    title: Simplify workflows to single CI
+    type: techdebt
+    area: ops
+    priority: P2
+    why: Reduce maintenance surface; rely on Vercel for deploys.
+    acceptance:
+      - Only .github/workflows/ci.yml exists
+      - Old Deploy.yml removed
+    status: done
+    links:
+      branch: chore/simple-ci-and-docs
+
+  - id: BL-006
+    title: Security and governance baseline
+    type: techdebt
+    area: ops
+    priority: P3
+    why: Enforce branch protections, required checks, secret scanning, and Dependabot.
+    acceptance:
+      - Branch protections on main/dev (required CI, review, linear history)
+      - Dependabot alerts enabled and visible
+      - Secret scanning + push protection on
+      - Optional: CodeQL workflow
+    status: planned
+    links: {}

--- a/docs/backlog/backlog.yaml
+++ b/docs/backlog/backlog.yaml
@@ -108,6 +108,7 @@ items:
     acceptance:
       - USAGE.md documents capture/persist, branch naming, commit, PR rules, lifecycle, diffs, hygiene, guardrails
       - New branches follow <type>/<BL-###>-<kebab-title>
+      - All new branches are created from main (default branch)
       - Commits include [BL-###] suffix and conventional commit format
       - PR template/title guidance included; PRs carry acceptance and checklist
     status: in-progress

--- a/docs/backlog/backlog.yaml
+++ b/docs/backlog/backlog.yaml
@@ -98,3 +98,18 @@ items:
     status: in-progress
     links:
       branch: chore/simple-ci-and-docs
+
+  - id: BL-008
+    title: Backlog steward enforcement
+    type: docs
+    area: ops
+    priority: P0
+    why: Enforce branch/commit/PR conventions tied to backlog IDs for traceability.
+    acceptance:
+      - USAGE.md documents capture/persist, branch naming, commit, PR rules, lifecycle, diffs, hygiene, guardrails
+      - New branches follow <type>/<BL-###>-<kebab-title>
+      - Commits include [BL-###] suffix and conventional commit format
+      - PR template/title guidance included; PRs carry acceptance and checklist
+    status: in-progress
+    links:
+      branch: docs/BL-008-backlog-steward-enforcement

--- a/docs/backlog/backlog.yaml
+++ b/docs/backlog/backlog.yaml
@@ -24,7 +24,10 @@ items:
       - Vitest server suite covers pulseRoutes, pulseApi, error handlers
       - v8 coverage >= 60% server-side
       - Tests run non-interactively via npm scripts
-    status: planned
+    status: in-progress
+    notes:
+      - Initial server tests and fixtures added (routes, middleware, services)
+      - SC2Pulse caching and error mapping covered; non-interactive Vitest config
     links:
       branch: test/server-suite
 
@@ -37,7 +40,10 @@ items:
     acceptance:
       - vitest.client.config.ts coverage.include limited to src/client/**
       - Pass with no tests enabled; sample test scaffold added
-    status: planned
+    status: in-progress
+    notes:
+      - Coverage include restricted to src/client/** and passWithNoTests enabled
+      - MSW/RTL scaffolding planned next
     links:
       branch: test/client-coverage-scope
 

--- a/docs/backlog/backlog.yaml
+++ b/docs/backlog/backlog.yaml
@@ -22,7 +22,7 @@ items:
     why: Cover routes/middleware/services, esp. SC2Pulse caching and error mapping.
     acceptance:
       - Vitest server suite covers pulseRoutes, pulseApi, error handlers
-      - v8 coverage  60% server-side
+    - v8 coverage >= 60% server-side
       - Tests run non-interactively via npm scripts
     status: planned
     links:

--- a/docs/backlog/backlog.yaml
+++ b/docs/backlog/backlog.yaml
@@ -22,7 +22,7 @@ items:
     why: Cover routes/middleware/services, esp. SC2Pulse caching and error mapping.
     acceptance:
       - Vitest server suite covers pulseRoutes, pulseApi, error handlers
-    - v8 coverage >= 60% server-side
+      - v8 coverage >= 60% server-side
       - Tests run non-interactively via npm scripts
     status: planned
     links:
@@ -83,3 +83,18 @@ items:
       - Optional: CodeQL workflow
     status: planned
     links: {}
+
+  - id: BL-007
+    title: Fix dual deploy env mapping
+    type: techdebt
+    area: ops
+    priority: P0
+    why: Vercel has dev/prod but both point to the same Render instance; enforce proper environment separation to avoid cross-environment traffic.
+    acceptance:
+      - Vercel dev deploy points to Render dev (or isolated dev URL/env)
+      - Vercel prod deploy points to Render prod instance
+      - Environment variables scoped per env in Vercel and Render
+      - Mapping documented in README/CONTRIBUTING
+    status: in-progress
+    links:
+      branch: chore/simple-ci-and-docs


### PR DESCRIPTION
*Summary*
- Purpose: Establish backlog stewardship rules and publish docs-only backlog.
- Scope: `docs/backlog/BACKLOG.md`, `docs/backlog/backlog.yaml`, `docs/backlog/USAGE.md`, `BACKLOG.md` (root stub).
- Notes: BL-002 and BL-003 marked in-progress with testing notes.

*Acceptance Checklist*
- [ ] Branch created from `main` per USAGE
- [ ] PR targets `dev` (docs-only changes)
- [ ] Backlog files render correctly on GitHub
- [ ] USAGE enforces branch-from-main, commit/PR conventions
- [ ] BL-007 and BL-008 present and linked
- [ ] CI passes (lint, tsc, tests, build)

*Links*
- Backlog: `docs/backlog/BACKLOG.md`
- USAGE: `docs/backlog/USAGE.md`
- backlog.yaml: `docs/backlog/backlog.yaml`