### PR TITLE
[BL-008] Add PR template enforcing BL-### + checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# PR Title
+
+- Use: [BL-###] concise summary
+
+## Summary
+- What changed and why
+- Scope and any exclusions
+
+## Acceptance Checklist
+- [ ] Branch created from `main` (per docs/backlog/USAGE.md)
+- [ ] PR targets `dev` unless a release to `main`
+- [ ] Includes a valid backlog ID in title and body (e.g., [BL-008])
+- [ ] CI green: eslint, tsc, tests, build
+- [ ] Minimal diff; unrelated changes excluded
+- [ ] Updated docs/backlog entries if applicable
+
+## Links
+- Backlog: docs/backlog/BACKLOG.md
+- USAGE: docs/backlog/USAGE.md
+- Item: BL-### (link to section in BACKLOG.md or backlog.yaml)
+
+## Notes for Reviewers
+- Risks, rollbacks, and targeted reviewers (CODEOWNERS applies)


### PR DESCRIPTION
*Summary*
- Add global PR template to enforce backlog stewardship rules.
- Requires [BL-###] in title, branch-from-main, CI green, and links to backlog.

*Acceptance Checklist*
- [ ] Branch created from `main`
- [ ] PR targets `dev`
- [ ] Title contains `[BL-###]`
- [ ] CI green (lint, tsc, tests, build)
- [ ] Backlog links included

*Links*
- Template: .github/pull_request_template.md
- USAGE: docs/backlog/USAGE.md