### PR TITLE
[BL-008] Add global PR template 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# PR Title
+
+- Use: [BL-###] concise summary
+
+## Summary
+- What changed and why
+- Scope and any exclusions
+
+## Acceptance Checklist
+- [ ] Branch created from `main` (per docs/backlog/USAGE.md)
+- [ ] PR targets `dev` unless a release to `main`
+- [ ] Includes a valid backlog ID in title and body (e.g., [BL-008])
+- [ ] CI green: eslint, tsc, tests, build
+- [ ] Minimal diff; unrelated changes excluded
+- [ ] Updated docs/backlog entries if applicable
+
+## Links
+- Backlog: docs/backlog/BACKLOG.md
+- USAGE: docs/backlog/USAGE.md
+- Item: BL-### (link to section in BACKLOG.md or backlog.yaml)
+
+## Notes for Reviewers
+- Risks, rollbacks, and targeted reviewers (CODEOWNERS applies)


### PR DESCRIPTION
Promote the PR template from docs/BL-008-pr-template to main. This was tested via PR to dev, and only introduces `.github/pull_request_template.md`. CI should remain green.