### PR TITLE
fix(analytics): Add lastPlayed field to player analytics data

### DIFF
--- a/src/server/services/analyticsService.ts
+++ b/src/server/services/analyticsService.ts
@@ -225,6 +225,7 @@ export class AnalyticsService {
                 gamesPerRace: player.gamesPerRace || {},
                 winRate: player.winRate,
                 rank: player.rank,
+                lastPlayed: player.lastPlayed || null,
             }))
         }
     }
@@ -417,7 +418,7 @@ export class AnalyticsService {
 
         players.forEach(player => {
             const hours = OnlineStatusCalculator.getHoursSinceLastActivity(
-                player.lastDatePlayed
+                player.lastPlayed
             )
 
             if (hours !== null) {
@@ -442,8 +443,8 @@ export class AnalyticsService {
         const dailyActivity = Array(7).fill(0)
 
         players.forEach(player => {
-            if (player.lastDatePlayed) {
-                const date = DateTime.fromISO(player.lastDatePlayed)
+            if (player.lastPlayed) {
+                const date = DateTime.fromISO(player.lastPlayed)
                 if (date.isValid) {
                     hourlyActivity[date.hour]++
                     dailyActivity[date.weekday - 1]++

--- a/src/server/services/dataDerivations.ts
+++ b/src/server/services/dataDerivations.ts
@@ -35,6 +35,7 @@ export interface TeamStats {
 }
 
 export interface RankingPlayer {
+    lastPlayed: any
     playerCharacterId: string
     btag?: string
     name?: string
@@ -418,7 +419,8 @@ export class DataDerivationsService {
                 gamesThisSeason: derivedStats.gamesThisSeason || 0,
                 gamesPerRace: derivedStats.gamesPerRace || { TERRAN: 0, PROTOSS: 0, ZERG: 0, RANDOM: 0 },
                 lastDatePlayed: derivedStats.lastDatePlayed || null,
-                online: derivedStats.online || false
+                online: derivedStats.online || false,
+                lastPlayed: derivedStats.lastDatePlayed || null
             }
 
             ranking.push(player)

--- a/src/server/services/playerAnalyticsPersistence.ts
+++ b/src/server/services/playerAnalyticsPersistence.ts
@@ -361,7 +361,13 @@ export class PlayerAnalyticsPersistence {
                     feature: 'persistence'
                 }, 'Completed cleanup of old backups')
             }
-
+            if(deletedCount === 0) {
+                logger.info({
+                    deletedCount,
+                    retentionDays: RETENTION_DAYS,
+                    feature: 'persistence'
+                }, 'No old backups to delete')
+            }
             return deletedCount
 
         } catch (error) {

--- a/src/server/services/pulseApi.ts
+++ b/src/server/services/pulseApi.ts
@@ -293,6 +293,7 @@ export const getTop = async (retries = 0, maxRetries = 3): Promise<any[]> => {
                                 ratingLast: highestRatingObj?.rating ?? null,
                                 leagueTypeLast: highestLeagueType,
                                 gamesThisSeason,
+                                lastPlayed: highestRatingObj?.lastPlayed ?? null,
                             }
                         })
                     )                    // Store in cache for 30 seconds (lru-cache handles TTL)


### PR DESCRIPTION
Introduces the lastPlayed property to player analytics objects and updates references from lastDatePlayed to lastPlayed for consistency. Also adds logging for cases where no old backups are deleted in playerAnalyticsPersistence.